### PR TITLE
Resolve service URLs dynamically.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 # Vim swap
 *.swp
 
+# Local build
+config.mk
+
 # Environment
 .env
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,38 @@
-ARG utility_prefix=ghcr.io/amrc-factoryplus/utilities
-ARG utility_ver=v1.0.6
+# syntax=docker/dockerfile:1
 
-FROM ${utility_prefix}-build:${utility_ver} AS build
+ARG acs_build=ghcr.io/amrc-factoryplus/utilities-build:v1.0.9
+ARG acs_run=ghcr.io/amrc-factoryplus/utilities-run:v1.0.9
 
-# Install the node application on the build container where we can compile the native modules.
-RUN install -d -o node -g node /home/node/app
+FROM ${acs_build} AS build
+ARG acs_npm=NO
+
+USER root
+RUN <<'SHELL'
+    install -d -o node -g node /home/node/app
+    apk add git
+SHELL
 WORKDIR /home/node/app
 USER node
-COPY package.json ./
-RUN npm install --save=false
-COPY . .
+COPY package*.json ./
+RUN <<'SHELL'
+    touch /home/node/.npmrc
+    if [ "${acs_npm}" != NO ]
+    then
+        npm config set @amrc-factoryplus:registry "${acs_npm}"
+    fi
 
-FROM ${utility_prefix}-run:${utility_ver}
+    npm install --save=false
+SHELL
+COPY --chown=node . .
+RUN <<'SHELL'
+    git describe --tags --dirty \
+        | sed -re's/-[0-9]+-/-/;s/(.*)/export const GIT_VERSION="\1";/' \
+        > lib/git-version.js
+SHELL
 
+FROM ${acs_run} AS run
 # Copy across from the build container.
 WORKDIR /home/node/app
 COPY --from=build --chown=root:root /home/node/app ./
-
 USER node
 CMD npm start

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,58 @@
+# On Windows try https://frippery.org/busybox/
+
+-include config.mk
+
+pkgver!=node -e 'console.log(JSON.parse(fs.readFileSync("package.json")).version)'
+
+version?=${pkgver}
+suffix?=
+registry?=ghcr.io/amrc-factoryplus
+repo?=acs-directory
+
+tag=${registry}/${repo}:${version}${suffix}
+build_args=
+
+ifdef acs_base
+build_args+=--build-arg acs_base="${acs_base}"
+endif
+
+ifdef acs_npm
+build_args+=--build-arg acs_npm="${acs_npm}"
+endif
+
+all: build push
+
+.PHONY: all build push check-committed
+
+check-committed:
+	[ -z "$$(git status --porcelain)" ] || (git status; exit 1)
+
+build: check-committed
+	docker build -t "${tag}" ${build_args} .
+
+push:
+	docker push "${tag}"
+
+run:
+	docker run -ti --rm "${tag}" /bin/sh
+
+.PHONY: deploy restart logs
+
+ifdef deployment
+
+deploy: all restart logs
+
+restart:
+	kubectl rollout restart deploy/"${deployment}"
+	kubectl rollout status deploy/"${deployment}"
+	sleep 2
+
+logs:
+	kubectl logs -f deploy/"${deployment}"
+
+else
+
+deploy restart logs:
+	: Set $${deployment} for automatic k8s deployment
+
+endif

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,0 +1,393 @@
+openapi: 3.0.0
+
+info:
+    title: Factory+ / AMRC Connectivity Stack (ACS) Directory component
+    version: 1.0.0
+    description: This service allows clients to search for devices across Factory+
+
+servers:
+    -   url: /v1
+        description: Directory API v1
+
+security:
+    - basic: []
+    - gssapi: []
+    - token: []
+
+paths:
+    /search:
+        get:
+            summary: Search for devices known to the system.
+            operationId: search
+            responses:
+                "200":
+                    description: List of matching devices.
+                    content:
+                        application/json:
+                            schema: { $ref: "#/components/schemas/device-list" }
+                "401": { description: "Unauthorised" }
+                "403": { description: "Forbidden" }
+
+    /address:
+        get:
+            summary: Get information about the known Sparkplug Group-IDs.
+            responses:
+                "200":
+                    description: Sparkplug Group-IDs.
+                    content:
+                        application/json:
+                            schema: { $ref: "#/components/schemas/address-info" }
+    /address/{group}:
+        parameters:
+            -   name: group
+                in: path
+                required: true
+                schema: { $ref: "#/components/schemas/sparkplug-name" }
+        get:
+            summary: Get information about Nodes in a given Group.
+            responses:
+                "200":
+                    description: Sparkplug Node-IDs.
+                    content:
+                        application/json:
+                            schema: { $ref: "#/components/schemas/address-info" }
+    /address/{group}/{node}:
+        parameters:
+            -   name: group
+                in: path
+                required: true
+                schema: { $ref: "#/components/schemas/sparkplug-name" }
+            -   name: node
+                in: path
+                required: true
+                schema: { $ref: "#/components/schemas/sparkplug-name" }
+        get:
+            summary: Get information about Devices under a given Node.
+            responses:
+                "200":
+                    description: Information about a Sparkplug Node.
+                    content:
+                        application/json:
+                            schema: { $ref: "#/components/schemas/address-info" }
+    /address/{group}/{node}/{device}:
+        parameters:
+            -   name: group
+                in: path
+                required: true
+                schema: { $ref: "#/components/schemas/sparkplug-name" }
+            -   name: node
+                in: path
+                required: true
+                schema: { $ref: "#/components/schemas/sparkplug-name" }
+            -   name: device
+                in: path
+                required: true
+                schema: { $ref: "#/components/schemas/sparkplug-name" }
+        get:
+            summary: Get information about a particular Device.
+            responses:
+                "200":
+                    description: Information about a Sparkplug Device.
+                    content:
+                        application/json:
+                            schema: { $ref: "#/components/schemas/address-info" }
+
+    /device:
+        get:
+            summary: List all known devices.
+            responses:
+                "200":
+                    description: A list of all known device UUIDs.
+                    content:
+                        application/json:
+                            schema: { $ref: "#/components/schemas/uuid-list" }
+
+    /device/{device}:
+        get:
+            summary: Get information about a particular device.
+            operationId: device
+            parameters:
+                -   { $ref: "#/components/parameters/device" }
+            responses:
+                "200":
+                    description: Information about the device.
+                    content:
+                        application/json:
+                            schema: { $ref: "#/components/schemas/device" }
+                "401": { description: "Unauthorised" }
+                "403": { description: "Forbidden" }
+
+    /device/{device}/history:
+        get:
+            summary: Get the online/offline history of a device.
+            operationId: device-history
+            description: >
+                Retrieve the history of this device's online/offline status. If start date is
+                omitted, go back as far as we have records of this device. If end date is omitted,
+                return up to the most recent birth or death.
+            parameters:
+                -   { $ref: "#/components/parameters/device" }
+                -   name: start
+                    description: Include records on or after this time.
+                    in: query
+                    schema: { type: string, format: date-time }
+                -   name: finish
+                    description: Include records on or before this time.
+                    in: query
+                    schema: { type: string, format: date-time }
+            responses:
+                "200":
+                    description: The requested history of the device.
+                    content:
+                        application/json:
+                            schema: { $ref: "#/components/schemas/session-list" }
+                "401": { description: "Unauthorised" }
+                "403": { description: "Forbidden" }
+
+    /schema:
+        get:
+            summary: List all the known schema UUIDs.
+            responses:
+                "200":
+                    description: A list of the known schemas.
+                    content:
+                        application/json:
+                            schema: { $ref: "#/components/schemas/uuid-list" }
+
+    /schema/{schema}/devices:
+        parameters:
+            -   { $ref: "#/components/parameters/schema" }
+        get:
+            summary: List all devices currently using this schema.
+            description: >
+                Retrieve a list of UUID of the devices that currently advertise this schema in their
+                birth certificate. This will include devices that are currently offline, but will
+                not include devices that have used this schema in the past but which did not use it
+                in their most recent birth certificate.
+            responses:
+                "200":
+                    description: A list of device UUIDs.
+                    content:
+                        application/json:
+                            schema: { $ref: "#/components/schemas/uuid-list" }
+
+    /service:
+        get:
+            summary: List all the known service UUIDs.
+            responses:
+                "200":
+                    description: A list of the known services.
+                    content:
+                        application/json:
+                            schema: { $ref: "#/components/schemas/uuid-list" }
+
+    /service/{service}:
+        parameters:
+            - { $ref: "#/components/parameters/service" }
+        get:
+            summary: Return a list of devices providing this service.
+            responses:
+                "200":
+                    description: A list of service providers.
+                    content:
+                        application/json:
+                            schema: { $ref: "#/components/schemas/service-provider-list" }
+
+    /service/{service}/advertisment:
+        parameters:
+            - { $ref: "#/components/parameters/service" }
+        get:
+            summary: Fetch my service advertisment.
+            responses:
+                "200":
+                    description: Current service advertisment.
+                    content:
+                        application/json:
+                            schema: { $ref: "#/components/schemas/service-provider" }
+        put:
+            summary: Advertise a service.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema: { $ref: "#/components/schemas/service-provider" }
+            responses:
+                "201":
+                    description: Advertisment created.
+                "204":
+                    description: Advertisment updated.
+        delete:
+            summary: Remove a service advertisment.
+            responses:
+                "204":
+                    description: Advertisment removed.
+
+    /service/{service}/advertisment/{owner}:
+        parameters:
+            - { $ref: "#/components/parameters/service" }
+            - { $ref: "#/components/parameters/owner" }
+        get:
+            summary: Fetch a service advertisment.
+            responses:
+                "200":
+                    description: Current service advertisment.
+                    content:
+                        application/json:
+                            schema: { $ref: "#/components/schemas/service-provider" }
+        put:
+            summary: Advertise a service.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema: { $ref: "#/components/schemas/service-provider" }
+            responses:
+                "201":
+                    description: Advertisment created.
+                "204":
+                    description: Advertisment updated.
+        delete:
+            summary: Remove a service advertisment.
+            responses:
+                "204":
+                    description: Advertisment removed.
+                    
+components:
+    parameters:
+        device:
+            description: The UUID of the device we are querying.
+            name: device
+            in: path
+            required: true
+            schema: { type: string, format: uuid }
+
+        schema:
+            description: The UUID of the schema we are querying.
+            name: schema
+            in: path
+            required: true
+            schema: { type: string, format: uuid }
+
+        service:
+            description: The UUID of the service we are querying.
+            name: service
+            in: path
+            required: true
+            schema: { type: string, format: uuid }
+
+        owner:
+            description: The provider of the service.
+            name: owner
+            in: path
+            required: true
+            schema: { type: string, format: uuid }
+
+    schemas:
+        sparkplug-name:
+            description: A Sparkplug name component.
+            type: string
+            pattern: '^[a-zA-Z0-9_-]+$'
+
+        uuid-list:
+            description: A list of UUIDs.
+            type: array
+            items: { type: string, format: uuid }
+
+        address-info:
+            description: >
+                Information about the devices currently using a given section of the Sparkplug
+                namespace.
+            type: object
+            required: [address]
+            properties:
+                address:
+                    type: string
+                    description: The Sparkplug address we refer to.
+                uuid:
+                    type: string
+                    format: uuid
+                    description: >
+                        The UUID of the device to most recently publish to this address, if any.
+                children:
+                    type: array
+                    items: { $ref: "#/components/schemas/sparkplug-name" }
+                    description: >
+                        The names of the known children of this branch of the tree. If this is a
+                        Group, the children will be Nodes. If this is a Node, the children will be
+                        Devices.
+
+        device:
+            description: >
+                A description of a single Sparkplug device. If deviceId is present the device is a
+                Sparkplug Device, otherwise it is an EON Node. online indicates if the device is
+                online at the moment. lastChange indicates the last time a BIRTH or DEATH was seen.
+                schemas is a list of all schemas used by the most recent birth certificate.
+            type: object
+            required: [uuid, group_id, node_id, online, last_change]
+            properties:
+                uuid: { type: string, format: uuid }
+                group_id: { $ref: "#/components/schemas/sparkplug-name" }
+                node_id: { $ref: "#/components/schemas/sparkplug-name" }
+                device_id: { $ref: "#/components/schemas/sparkplug-name" }
+                online: { type: boolean }
+                last_change: { type: string, format: date-time }
+                schemas: { $ref: "#/components/schemas/uuid-list" }
+                top_schema: { type: string, format: uuid }
+                
+        device-list:
+            description: >
+                Represents a list of devices. Order is unimportant.
+            type: array
+            items: { $ref: "#/components/schemas/device" }
+
+        service-provider-list:
+            description: A list of devices which provide a service.
+            type: array
+            items: { $ref: "#/components/schemas/service-provider" }
+
+        service-provider:
+            description: Information about where a service provider can be accessed.
+            type: object
+            properties:
+                device: { type: string, format: uuid }
+                url: { type: string }
+
+        session:
+            description: >
+                A record describing a single device session (the period
+                between a BIRTH and a DEATH or reBIRTH). If finish is
+                not present the session has not yet ended. 
+            type: object
+            required: [groupId, nodeId, start, templates]
+            properties:
+                groupId: { $ref: "#/components/schemas/sparkplug-name" }
+                nodeId: { $ref: "#/components/schemas/sparkplug-name" }
+                deviceId: { $ref: "#/components/schemas/sparkplug-name" }
+                start: { type: string, format: date-time }
+                finish: { type: string, format: date-time }
+                death: { type: boolean }
+                schemas: { $ref: "#/components/schemas/uuid-list" }
+
+        session-list:
+            description: >
+                Represents a list of sessions for a particular device; note that a device may not
+                necessarily have the same group/node/device ID every time it comes online. The list
+                MUST be sorted by birth time, newest first. Entries that overlap in time indicate a
+                problem on the network, but MUST be reported as seen on the wire. Clients MUST
+                correctly handle overlapping entries.
+            type: array
+            items: { $ref: "#/components/schemas/session" }
+
+    securitySchemes:
+        basic:
+            type: http
+            description: User/password HTTP Basic auth
+            scheme: Basic
+        gssapi:
+            type: http
+            description: HTTP Negotiate auth (Kerberos)
+            scheme: Negotiate
+        token:
+            type: http
+            description: HTTP bearer token auth
+            scheme: Bearer

--- a/bin/directory-webapi.js
+++ b/bin/directory-webapi.js
@@ -28,6 +28,7 @@ fplus.set_service_discovery(model.find_service_url.bind(model));
 const api = await new APIv1({
     model,
     fplus,
+    internal_hostname:  process.env.HOSTNAME,
 }).init();
 
 const app = await new WebAPI({

--- a/bin/directory-webapi.js
+++ b/bin/directory-webapi.js
@@ -6,13 +6,15 @@
  * Copyright 2021 AMRC.
  */
 
-import { ServiceClient, WebAPI, UUIDs, pkgVersion } from "@amrc-factoryplus/utilities";
+import { ServiceClient, WebAPI, UUIDs } from "@amrc-factoryplus/utilities";
 
 import Model from "../lib/model.js";
 import APIv1 from "../lib/api_v1.js";
 import { Perm } from "../lib/uuids.js";
+import { GIT_VERSION } from "../lib/git-version.js";
 
-const Version = pkgVersion(import.meta);
+/* This is the version of the service spec we support. */
+const Version = "1.0.0";
 
 const model = await new Model({
     readonly: true,
@@ -36,6 +38,11 @@ const app = await new WebAPI({
         version:    Version,
         service:    UUIDs.Service.Directory,
         device:     process.env.DEVICE_UUID,
+        software: {
+            vendor:         "AMRC",
+            application:    "acs-directory",
+            revision:       GIT_VERSION,
+        },
     },
     keytab:     process.env.SERVER_KEYTAB,
     http_port:  process.env.PORT,

--- a/config.mk
+++ b/config.mk
@@ -1,0 +1,5 @@
+registry=amrc-factoryplus.shef.ac.uk:5000
+deployment=directory-webapi
+suffix=-bmz
+#acs_base=${registry}/acs-base:1.0.0
+#acs_npm=https://npm.amrc-factoryplus-dev.shef.ac.uk

--- a/lib/api_v1.js
+++ b/lib/api_v1.js
@@ -8,10 +8,24 @@ import express from "express";
 import OpenApiValidator from "express-openapi-validator";
 import {Perm} from "./uuids.js";
 
+function fqdn_split (fqdn) {
+    return fqdn.match(/([^.]*)\.(.*)/).slice(1);
+}
+
+/* Grr. Specifying security by changing URL scheme is just stupid. */
+const _tlsmap = [
+    ["http", "https"],
+    ["mqtt", "mqtts"],
+    ["ws", "wss"],
+];
+const schemes = new Map(_tlsmap.map(v => [v[0], v]));
+const with_tls = new Set(_tlsmap.map(v => v[1]));
+
 export default class API {
     constructor(opts) {
         this.fplus = opts.fplus;
         this.model = opts.model;
+        this.internal = fqdn_split(opts.internal_hostname)[1];
 
         this.routes = express.Router();
     }
@@ -117,6 +131,29 @@ export default class API {
     async service_providers(req, res) {
         const uuid = req.params.service;
         const devs = await this.model.service_providers(uuid);
+
+        const fwd_fqdn = req.get("X-Forwarded-Host");
+        if (fwd_fqdn) {
+            const [, fwd_domain] = fqdn_split(fwd_fqdn);
+
+            const fwd_proto = req.get("X-Forwarded-Proto");
+            const scheme_ix = with_tls.has(fwd_proto) ? 1 : 0;
+
+            for (const dev of devs) {
+                const url = new URL(dev.url);
+                const [host, domain] = fqdn_split(url.hostname);
+                if (domain != this.internal)
+                    continue;
+
+                url.hostname = `${host}.${fwd_domain}`;
+                const protos = schemes.get(url.protocol);
+                if (protos)
+                    url.protocol = protos[scheme_ix]
+
+                dev.url = url.toString();
+            }
+        }
+
         res.status(200).json(devs);
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acs-directory",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "The Directory component of the AMRC Connectivity Stack",
   "author": "AMRC",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "webapi": "node bin/directory-webapi"
   },
   "dependencies": {
-    "@amrc-factoryplus/utilities": "^1.0.7",
+    "@amrc-factoryplus/utilities": "^1.0.9",
     "async": "^3.2.4",
     "express": "^4.17.1",
     "express-openapi-validator": "^4.13.2"


### PR DESCRIPTION
If a service has registered an internal URL, remap responses to requests that used an external Directory URL to include the corresponding external service URL.

This makes the following assumptions:
* The HOSTNAME environment variable is set to the Directory's **internal** hostname.
* Internal URLs are all non-TLS.
* The host part of external URLs matches the host part of internal URLs.

The ACS deployment currently meets all these.