### PR TITLE
Fix rewriting https URLs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 pkgver!=node -e 'console.log(JSON.parse(fs.readFileSync("package.json")).version)'
 
-version?=${pkgver}
+version?=v${pkgver}
 suffix?=
 registry?=ghcr.io/amrc-factoryplus
 repo?=acs-directory

--- a/lib/api_v1.js
+++ b/lib/api_v1.js
@@ -146,10 +146,11 @@ export default class API {
                     continue;
 
                 url.hostname = `${host}.${fwd_domain}`;
-                const protos = schemes.get(url.protocol);
+                const protos = schemes.get(url.protocol.slice(0,-1));
                 if (protos)
                     url.protocol = protos[scheme_ix]
 
+                console.log("Rewriting %s to %s", dev.url, url);
                 dev.url = url.toString();
             }
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acs-directory",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "The Directory component of the AMRC Connectivity Stack",
   "author": "AMRC",
   "license": "MIT",


### PR DESCRIPTION
The code to rewrite URLs based on the incoming request URL did not work when the incoming URL was https.