### PR TITLE
Update the OpenAPI spec

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,32 +6,8 @@ env:
 on:
   release:
     types: [ published ]
-    # Trigger only when a release with tag v*.*.* is published
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
-  update-version:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Update version in package.json
-        run: |
-          CURRENT_TAG=${GITHUB_REF#refs/tags/}
-          echo "Current tag: $CURRENT_TAG"
-          VERSION="${CURRENT_TAG#v}"
-          echo "Updating version to: $VERSION"
-          jq ".version = \"$VERSION\"" package.json > package.json.tmp
-          mv package.json.tmp package.json
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
-        with:
-          title: Update package.json version
-          branch: update-version
-          commit-message: Update package.json version
-          body: Update the version of `package.json` as part of release process
-          delete-branch: true
-          base: main
   build:
     runs-on: ubuntu-latest
     permissions:
@@ -47,9 +23,7 @@ jobs:
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6 #v2.6.0
-        with:
-          cosign-release: 'v1.13.1'
+        uses: sigstore/cosign-installer@v3.1.1
 
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
@@ -98,4 +72,4 @@ jobs:
           COSIGN_EXPERIMENTAL: "true"
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.
-        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}
+        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign --yes {}@${{ steps.build-and-push.outputs.digest }}

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -92,6 +92,60 @@ paths:
                         application/json:
                             schema: { $ref: "#/components/schemas/address-info" }
 
+    /alert:
+        get:
+            summary: >
+                List all known alerts. These endpoints are ALPHA; they
+                are subject to incompatible change in the future.
+            responses:
+                "200":
+                    description: Information about available alerts.
+                    content:
+                        application/json:
+                            schema: { $ref: "#/components/schemas/alert-list" }
+    /alert/active:
+        get:
+            summary: List all currently active alerts.
+            responses:
+                "200":
+                    description: Information about active alerts.
+                    content:
+                        application/json:
+                            schema: { $ref: "#/components/schemas/alert-list" }
+    /alert/type/{type}:
+        parameters:
+            - { $ref: "#/components/parameters/alert-type" }
+        get:
+            summary: List all alerts of the given type.
+            responses:
+                "200":
+                    description: Active alerts.
+                    content:
+                        application/json:
+                            schema: { $ref: "#/components/schemas/alert-list" }
+    /alert/type/{type}/active:
+        parameters:
+            - { $ref: "#/components/parameters/alert-type" }
+        get:
+            summary: List all active alerts of the given type.
+            responses:
+                "200":
+                    description: Active alerts of the given type.
+                    content:
+                        application/json:
+                            schema: { $ref: "#/components/schemas/alert-list" }
+    /alert/{alert}:
+        parameters:
+            - { $ref: "#/components/parameters/alert" }
+        get:
+            summary: Return the status of a particular alert.
+            responses:
+                "200":
+                    description: Status of the given alert.
+                    content:
+                        application/json:
+                            schema: { $ref: "#/components/schemas/alert" }
+
     /device:
         get:
             summary: List all known devices.
@@ -254,6 +308,20 @@ paths:
                     
 components:
     parameters:
+        alert:
+            description: The UUID of an individual alert.
+            name: alert
+            in: path
+            required: true
+            schema: { type: string, format: uuid }
+
+        alert-type:
+            description: The UUID of an alert type.
+            name: type
+            in: path
+            required: true
+            schema: { type: string, format: uuid }
+
         device:
             description: The UUID of the device we are querying.
             name: device
@@ -315,6 +383,50 @@ components:
                         The names of the known children of this branch of the tree. If this is a
                         Group, the children will be Nodes. If this is a Node, the children will be
                         Devices.
+
+        alert:
+            description: Information about a particular alert.
+            type: object
+            required: [uuid, device, type, metric, active, last_change]
+            properties:
+                uuid:
+                    description: The UUID of this individual alert.
+                    type: string
+                    format: uuid
+                device:
+                    description: >
+                        The UUID of the device which published this alert.
+                    type: string
+                    format: uuid
+                type:
+                    description: >
+                        A UUID identifying the category of alert this
+                        represents. These UUIDs should be registered in
+                        the ConfigDB with at least a human-readable name
+                        in the General Info app.
+                    type: string
+                    format: uuid
+                metric:
+                    description: >
+                        The path to the metric sub-tree within the
+                        device's metrics which represents this alert.
+                        Metrics here should conform to the Alert schema.
+                        Do not attach any significance to the metric
+                        names used; alerts must be identified by their
+                        type and their Links.
+                    type: string
+                active:
+                    description: Is this alert currently active?
+                    type: boolean
+                last_change:
+                    description: The time this alert last changed status.
+                    type: string
+                    format: date-time
+
+        alert-list:
+            description: A list of alerts.
+            type: array
+            items: { $ref: "#/components/schemas/alert" }
 
         device:
             description: >

--- a/lib/api_v1.js
+++ b/lib/api_v1.js
@@ -322,7 +322,7 @@ export default class API {
         const {uuid} = req.params;
         const auth = this.fplus.Auth;
 
-        const alrt = await this.model.alert_get(uuid);
+        const alrt = await this.model.alert_by_uuid(uuid);
 
         /* We have to unhelpfully return 403 here to avoid exposing
          * alert existence to unauthorised clients. */

--- a/lib/api_v1.js
+++ b/lib/api_v1.js
@@ -74,6 +74,11 @@ export default class API {
         /* Delete unimplemented for now. */
         //    .delete(this.service_advert_del.bind(this));
         
+        /* XXX These are ALPHA.
+         *  - It may be better for the list endpoints to return just a
+         *  list of UUIDs rather than the full info.
+         *  - We need to index the Links too, or this is a bit useless.
+         */
         api.get("/alert", this.alert_list.bind(this, false));
         api.get("/alert/active", this.alert_list.bind(this, true));
         api.get("/alert/type/:type", this.alert_list.bind(this, false));

--- a/lib/api_v1.js
+++ b/lib/api_v1.js
@@ -324,14 +324,15 @@ export default class API {
 
         const alrt = await this.model.alert_by_uuid(uuid);
 
-        /* We have to unhelpfully return 403 here to avoid exposing
-         * alert existence to unauthorised clients. */
-        if (alrt == null) return res.status(403).end();
-
         /* XXX timing attack */
+        if (alrt == null) return res.status(404).end();
+
         const ok = auth.check_acl(req.auth, Perm.Read_Alert_Type, alrt.type, true)
             || auth.check_acl(req.auth, Perm.Read_Device_Alerts, alrt.device, true);
-        if (!ok) return res.status(403).end();
+        /* We unhelpfully return 404 here to prevent unauthorised
+         * clients from discovering which alerts exist. This is
+         * consistent with removing them from the lists. */
+        if (!ok) return res.status(404).end();
         return res.status(200).json(alrt);
     }
 }

--- a/lib/api_v1.js
+++ b/lib/api_v1.js
@@ -39,11 +39,11 @@ export default class API {
         let api = this.routes;
 
         /* Validate against the spec */
-        //const spec = url.fileURLToPath(new URL("../api/openapi.yaml", import.meta.url));
-        //console.log(`Loading OpenAPI spec from ${spec}...`);
-        //api.use(OpenApiValidator.middleware({
-        //    apiSpec: spec,
-        //}));
+        const spec = url.fileURLToPath(new URL("../api/openapi.yaml", import.meta.url));
+        console.log(`Loading OpenAPI spec from ${spec}...`);
+        api.use(OpenApiValidator.middleware({
+            apiSpec: spec,
+        }));
 
         api.get("/search", this.search.bind(this));
 


### PR DESCRIPTION
If we're going to have this it should be correct.

Fix two small bugs in the Alerts API. Document that the Alerts API as a whole is alpha and may be subject to incompatible change later.